### PR TITLE
index.html: add a query parameter `stream=`

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,7 +316,17 @@
                     // toggles "Loading..."
                     loading: false
                 },
-                created: function() { this.refreshBuilds() },
+                created: function() {
+                    const searchParams = new URLSearchParams(window.location.search);
+                    if (searchParams.has('stream')) {
+                        const queryStream = searchParams.get('stream');
+                        if (["stable", "testing", "next", "testing-devel", "next-devel", "bodhi-updates", "developer"].includes(queryStream)) {
+                            this.stream = queryStream;
+                        }
+                    }
+
+                    this.refreshBuilds();
+                    },
                 watch: { stream: 'refreshBuilds' },
                 methods: {
                     refreshBuilds: function() {


### PR DESCRIPTION
Adds the ability to navigate to specific stream directly with URL parameter. This is useful when links can go to the desired stream directly without clicking on the dropdown list.

Also this is useful when Fedora CoreOS download page adds links to specific stream builds directly through the buttons `View xxx Releases`.

Related: https://pagure.io/fedora-websites/issue/964#comment-576026
Signed-off-by: Allen Bai <abai@redhat.com>