### PR TITLE
index.html: use replaceState instead of pushState

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,7 +334,7 @@
                 },
                 methods: {
                     updateURL: function() {
-                        history.pushState(null, null, `${window.location.origin + window.location.pathname}?stream=${this.stream}`);
+                        history.replaceState(null, null, `${window.location.origin + window.location.pathname}?stream=${this.stream}`);
                     },
                     refreshBuilds: function() {
                         this.loading = true


### PR DESCRIPTION
The reason is to address the issue that when users hit back button, the url changes but the stream dropdown is not return to the previous value and the view is not replaced with the previous view.

This is because the Vue instance is not watching the URL of the window and in order to do watch the URL, we might need to add vue-router library, which might be overkill for such a functionality. Therefore, replace the history stack when updating the stream in the first place.

History API: https://developer.mozilla.org/en-US/docs/Web/API/History
Signed-off-by: Allen Bai <abai@redhat.com>