### PR TITLE
index.html: add moby-engine to the important package list

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
 
             // pkgdiff enum to str
             const diffType = ["added", "removed", "upgraded", "downgraded"];
-            const importantPkgs = ["kernel", "systemd", "rpm-ostree", "ignition", "podman"];
+            const importantPkgs = ["kernel", "systemd", "rpm-ostree", "ignition", "podman", "moby-engine"];
 
             function getBaseUrl(stream, developer) {
                 return stream != "developer"


### PR DESCRIPTION
As discussed per https://github.com/coreos/fedora-coreos-tracker/issues/194#issuecomment-635683344, it makes sense to list `moby-engine` as one of the important packages.

Signed-off-by: Allen Bai <abai@redhat.com>