### PR TITLE
graph: Revert d3js update to v6

### DIFF
--- a/graph/index.html
+++ b/graph/index.html
@@ -6,7 +6,7 @@
     <title>Fedora CoreOS updates graph</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">
     <script defer src="https://use.fontawesome.com/releases/v5.15.1/js/all.js"></script>
-    <script src="https://d3js.org/d3.v6.min.js" charset="utf-8"></script>
+    <script src="https://d3js.org/d3.v5.min.js" charset="utf-8"></script>
     <script src="https://dagrejs.github.io/project/dagre-d3/v0.6.4/dagre-d3.js" charset="utf-8"></script>
 
     <script>


### PR DESCRIPTION
Temporary solution while we investigate the following issue:

```
Uncaught TypeError: Cannot read property 'transform' of undefined
    at SVGSVGElement.<anonymous> (graph:234)
    at at.call (d3.v6.min.js:2)
    at w.emit (d3.v6.min.js:2)
    at w.zoom (d3.v6.min.js:2)
    at SVGSVGElement.M (d3.v6.min.js:2)
    at SVGSVGElement.<anonymous> (d3.v6.min.js:2)
```

Partial revert of: ca30513 graph: Update javascript dependencies