### PR TITLE
browser: add rawhide

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -298,7 +298,7 @@
                 el: '#app',
                 data: {
                     // source of truth for streams
-                    streamList: ['stable', 'testing', 'next', 'testing-devel', 'next-devel', 'bodhi-updates', 'developer'],
+                    streamList: ['stable', 'testing', 'next', 'testing-devel', 'next-devel', 'rawhide', 'bodhi-updates', 'developer'],
                     // currently selected stream
                     stream: 'testing-devel',
                     // if current stream is "developer", currently entered developer


### PR DESCRIPTION
Prep for builds appearing there. Let's list it in front of
`bodhi-updates` for now since that one is currently dead.