### PR TITLE
browser: link to FCOS and COSA commits used for each build

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -45,6 +45,13 @@
                                         </div>
                                         <div v-if="build.meta" style="margin-left: 1em">
                                             <div class="content">
+                                                Metadata:
+                                                <ul>
+                                                    <li> FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.config-gitrev']">{{ build.meta['coreos-assembler.config-gitrev'] }}</a></li>
+                                                    <li> COSA Commit: <a v-bind:href="'https://github.com/coreos/coreos-assembler/commit/' + build.meta['coreos-assembler.container-image-git']['commit']">{{ build.meta['coreos-assembler.container-image-git']['commit'] }}</a></li>
+                                                </ul>
+                                            </div>
+                                            <div class="content">
                                                 OSTree:
                                                 <ul>
                                                     <li>Commit: {{ build.meta['ostree-commit'] }}


### PR DESCRIPTION
This is useful to have easily accessible and matches the RHCOS release
browser. Came up in:

https://github.com/coreos/fedora-coreos-tracker/issues/881#issuecomment-874198061