### PR TITLE
browser: support multiple architectures

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -37,8 +37,6 @@
                                     <div v-for="build in builds">
                                         <div class="content">
                                             Version: <span style="font-weight: bold">{{ build.id }}</span>
-                                            (<a v-bind:href="getObjectUrl(build, 'meta.json')">meta.json</a>,
-                                            <a v-bind:href="getObjectUrl(build, 'commitmeta.json')">commitmeta.json</a>)
                                             <span v-if="build.meta" v-bind:title="build.meta['coreos-assembler.build-timestamp']">
                                                 — {{ timeSince(build.meta['coreos-assembler.build-timestamp']) }}
                                             </span>
@@ -49,6 +47,7 @@
                                                 <ul>
                                                     <li> FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.config-gitrev']">{{ build.meta['coreos-assembler.config-gitrev'] }}</a></li>
                                                     <li> COSA Commit: <a v-bind:href="'https://github.com/coreos/coreos-assembler/commit/' + build.meta['coreos-assembler.container-image-git']['commit']">{{ build.meta['coreos-assembler.container-image-git']['commit'] }}</a></li>
+                                                    <li> Raw: <a v-bind:href="getObjectUrl(build, 'meta.json')">meta.json</a> <a v-bind:href="getObjectUrl(build, 'commitmeta.json')">commitmeta.json</a></li>
                                                 </ul>
                                             </div>
                                             <div class="content">

--- a/browser/index.html
+++ b/browser/index.html
@@ -220,7 +220,10 @@
                                             <hr>
                                         </div>
                                         <div v-else style="margin-left: 1em">
-                                            Loading...
+                                            <div class="content">
+                                                Loading...
+                                            </div>
+                                            <hr>
                                         </div>
                                     </div>
                                     <div v-if="unshown_builds.length > 0">

--- a/browser/index.html
+++ b/browser/index.html
@@ -318,10 +318,7 @@
                 return `<a href="${cve[0]}">${cve[1]}</a>`;
             }
 
-            function getArtifactUrl(base, build, path, legacy) {
-                if (legacy) {
-                    return `${base}/${build.id}/${path}`;
-                }
+            function getArtifactUrl(base, build, path) {
                 // XXX: just return for the first arch for now; multi-arch
                 // requires reworking the page layout
                 return `${base}/${build.id}/${build.arches[0]}/${path}`;
@@ -331,12 +328,12 @@
                 return fetch(`${base}/builds.json`)
                     .then(response => response.ok ? response.json() : {"builds": []})
                     .then(data => {
-                        if (!('schema-version' in data) || data["schema-version"] != "1.0.0") {
-                            // in legacy mode, just assume we only built x86_64
-                            return [true, data.builds.map(id => ({'id': id, 'arches': ['x86_64'], 'meta': null, 'commitmeta': null}))];
-                        } else {
-                            return [false, data.builds.map(build => ({'id': build.id, 'arches': build.arches, 'meta': null, 'commitmeta': null}))];
-                        }
+                            return data.builds.map(build => ({
+                                'id': build.id,
+                                'arches': build.arches,
+                                'meta': null,
+                                'commitmeta': null
+                            }));
                     });
             }
 
@@ -359,14 +356,14 @@
                 return r;
             }
 
-            function fetchBuild(base, build, legacy) {
-                fetchBuildMeta(base, build, legacy).then(result => {
+            function fetchBuild(base, build) {
+                fetchBuildMeta(base, build).then(result => {
                     [basearch, meta] = result;
                     sortPkgDiff(meta);
                     // show the build metadata
                     build.meta = meta;
                     // and fetch extra commit metadata in async
-                    fetchBuildCommitMeta(base, build, basearch, legacy).then(commitmeta => {
+                    fetchBuildCommitMeta(base, build, basearch).then(commitmeta => {
                         commitmeta["importantPkgs"] = findImportantPkgs(commitmeta);
                         commitmeta["showImportantPkgsOnly"] = true;
                         build.commitmeta = commitmeta;
@@ -374,11 +371,7 @@
                 });
             }
 
-            function fetchBuildMeta(base, build, legacy) {
-                if (legacy) {
-                    return fetch(`${base}/${build.id}/meta.json`)
-                        .then(response => Promise.all([build.arches[0], response.ok ? response.json() : {}]));
-                }
+            function fetchBuildMeta(base, build) {
                 // XXX: just fetch the meta for the first arch right now
                 return fetch(`${base}/${build.id}/${build.arches[0]}/meta.json`)
                     .then(response => Promise.all([build.arches[0], response.ok ? response.json() : {}]));
@@ -389,11 +382,7 @@
                 // }));
             }
 
-            function fetchBuildCommitMeta(base, build, basearch, legacy) {
-                if (legacy) {
-                    return fetch(`${base}/${build.id}/commitmeta.json`)
-                        .then(response => response.ok ? response.json() : {});
-                }
+            function fetchBuildCommitMeta(base, build, basearch) {
                 return fetch(`${base}/${build.id}/${basearch}/commitmeta.json`)
                     .then(response => response.ok ? response.json() : {});
             }
@@ -413,12 +402,8 @@
                     developer: "",
                     // current url to builds/ dir for stream
                     buildsUrl: "",
-                    // whether the currently selected stream has a legacy layout
-                    // https://github.com/coreos/coreos-assembler/pull/580
-                    legacy: false,
                     // list of {id, arches, meta, commitmeta} build objects
-                    // XXX: in non-legacy mode, meta and commitmeta are those
-                    // of the first arch, but in the future these would be e.g.
+                    // XXX: in the future these would be e.g.
                     // meta[arch] and commitmeta[arch]
                     builds: [],
                     // list of unshown {id, arches, meta, commitmeta} build objects
@@ -453,11 +438,9 @@
                     refreshBuilds: function() {
                         this.loading = true
                         this.buildsUrl = getBaseUrl(this.stream, this.developer) + "/builds"
-                        fetchBuilds(this.buildsUrl).then(result => {
-                            [legacy, builds] = result;
+                        fetchBuilds(this.buildsUrl).then(builds => {
                             // first populate and show the build list
                             this.loading = false;
-                            this.legacy = legacy;
                             this.builds = [];
                             this.unshown_builds = [];
 
@@ -465,7 +448,7 @@
                             builds.forEach((build, idx) => {
                                 if (idx < initialBuildsShown) {
                                     this.builds.push(build);
-                                    fetchBuild(this.buildsUrl, build, this.legacy);
+                                    fetchBuild(this.buildsUrl, build);
                                 } else {
                                     this.unshown_builds.push(build);
                                 }
@@ -478,7 +461,7 @@
                         unshown_builds.forEach((build, idx) => {
                             if (n < 0 || idx < n) {
                                 this.builds.push(build);
-                                fetchBuild(this.buildsUrl, build, this.legacy);
+                                fetchBuild(this.buildsUrl, build);
                             } else {
                                 this.unshown_builds.push(build);
                             }
@@ -486,18 +469,18 @@
                     },
                     getImageUrl: function(build, type) {
                         var path = build.meta['images'][type]['path'];
-                        var url = getArtifactUrl(this.buildsUrl, build, path, this.legacy);
+                        var url = getArtifactUrl(this.buildsUrl, build, path);
                         return `<a href="${url}">${path}</a> ` +
                             `(<a title="Copy image link to clipboard" class="js"
                                  onclick="copyToClipboard('${url}')">copy link</a>)`;
                     },
                     getObjectUrl: function(build, path) {
-                        return getArtifactUrl(this.buildsUrl, build, path, this.legacy);
+                        return getArtifactUrl(this.buildsUrl, build, path);
                     },
                     getOSTreeUrl: function(build) {
                         if ('ostree' in build.meta['images']) {
                             var path = build.meta['images']['ostree']['path'];
-                            return getArtifactUrl(this.buildsUrl, build, path, this.legacy)
+                            return getArtifactUrl(this.buildsUrl, build, path);
                         }
                         return this.getObjectUrl(build, "ostree-commit.tar")
                     },

--- a/browser/index.html
+++ b/browser/index.html
@@ -327,11 +327,6 @@
                 return `${base}/${build.id}/${build.arches[0]}/${path}`;
             }
 
-            function createArtifactLink(base, build, path, legacy) {
-                var url = getArtifactUrl(base, build, path, legacy);
-                return `<a href="${url}">${path}</a>`;
-            }
-
             function fetchBuilds(base) {
                 return fetch(`${base}/builds.json`)
                     .then(response => response.ok ? response.json() : {"builds": []})
@@ -505,9 +500,6 @@
                             return getArtifactUrl(this.buildsUrl, build, path, this.legacy)
                         }
                         return this.getObjectUrl(build, "ostree-commit.tar")
-                    },
-                    getObjectLink: function(build, path) {
-                        return createArtifactLink(this.buildsUrl, build, path, this.legacy);
                     },
                     getPkgNevra: function(tuple) {
                         return `${tuple[0]}-${tuple[1]}.${tuple[2]}`;

--- a/browser/index.html
+++ b/browser/index.html
@@ -219,6 +219,12 @@
                                             </div>
                                             <hr>
                                         </div>
+                                        <div v-else-if="!build.arches.includes(arch)" style="margin-left: 1em">
+                                            <div class="content">
+                                                Not available on architecture {{ arch }}.
+                                            </div>
+                                            <hr>
+                                        </div>
                                         <div v-else style="margin-left: 1em">
                                             <div class="content">
                                                 Loading...
@@ -280,6 +286,23 @@
                                     </div>
                                 </nav>
                             </div>
+                            <!-- Arch selector -->
+                            <div class="tile is-vertical is-12 is-child">
+                                <nav class="panel is-danger">
+                                    <p class="panel-heading has-text-centered">Architecture</p>
+                                    <div class="panel-block">
+                                        <div class="field has-addons">
+                                            <p class="control">
+                                                <span class="select">
+                                                    <select v-model="arch">
+                                                        <option v-for="archItem in archList" :value="archItem">{{ archItem }}</option>
+                                                    </select>
+                                                </span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </nav>
+                            </div>
                         </nav>
                     </div>
                 </div>
@@ -320,10 +343,8 @@
                 return `<a href="${cve[0]}">${cve[1]}</a>`;
             }
 
-            function getArtifactUrl(base, build, path) {
-                // XXX: just return for the first arch for now; multi-arch
-                // requires reworking the page layout
-                return `${base}/${build.id}/${build.arches[0]}/${path}`;
+            function getArtifactUrl(base, build, arch, path) {
+                return `${base}/${build.id}/${arch}/${path}`;
             }
 
             function fetchBuilds(base) {
@@ -334,7 +355,9 @@
                                 'id': build.id,
                                 'arches': build.arches,
                                 'meta': null,
-                                'commitmeta': null
+                                'metas': {},
+                                'commitmeta': null,
+                                'commitmetas': {},
                             }));
                     });
             }
@@ -358,34 +381,42 @@
                 return r;
             }
 
-            function fetchBuild(base, build) {
-                fetchBuildMeta(base, build).then(result => {
-                    [basearch, meta] = result;
+            function fetchBuild(base, build, arch) {
+                // is that arch even available for this build?
+                if (!build.arches.includes(arch)) {
+                    build.meta = null;
+                    build.commitmeta = null;
+                    return;
+                }
+                // did we fetch it already?
+                if (arch in build.commitmetas) {
+                    build.meta = build.metas[arch];
+                    build.commitmeta = build.commitmetas[arch];
+                    return;
+                }
+                // fetch it
+                fetchBuildMeta(base, build, arch).then(meta => {
                     sortPkgDiff(meta);
                     // show the build metadata
                     build.meta = meta;
+                    build.metas[arch] = meta;
                     // and fetch extra commit metadata in async
-                    fetchBuildCommitMeta(base, build, basearch).then(commitmeta => {
+                    fetchBuildCommitMeta(base, build, arch).then(commitmeta => {
                         commitmeta["importantPkgs"] = findImportantPkgs(commitmeta);
                         commitmeta["showImportantPkgsOnly"] = true;
                         build.commitmeta = commitmeta;
+                        build.commitmetas[arch] = commitmeta;
                     });
                 });
             }
 
-            function fetchBuildMeta(base, build) {
-                // XXX: just fetch the meta for the first arch right now
-                return fetch(`${base}/${build.id}/${build.arches[0]}/meta.json`)
-                    .then(response => Promise.all([build.arches[0], response.ok ? response.json() : {}]));
-
-                // return Promise.all(build.arches.map(arch => {
-                //     fetch(`${base}/${build.id}/${arch}/meta.json`)
-                //         .then(response => Promise.all([arch, response.ok ? response.json() : {}]));
-                // }));
+            function fetchBuildMeta(base, build, arch) {
+                return fetch(`${base}/${build.id}/${arch}/meta.json`)
+                    .then(response => response.ok ? response.json() : {});
             }
 
-            function fetchBuildCommitMeta(base, build, basearch) {
-                return fetch(`${base}/${build.id}/${basearch}/commitmeta.json`)
+            function fetchBuildCommitMeta(base, build, arch) {
+                return fetch(`${base}/${build.id}/${arch}/commitmeta.json`)
                     .then(response => response.ok ? response.json() : {});
             }
 
@@ -396,17 +427,19 @@
             var app = new Vue({
                 el: '#app',
                 data: {
-                    // source of truth for streams
+                    // source of truth for streams; ideally this would come from some higher-level source of truth
                     streamList: ['stable', 'testing', 'next', 'testing-devel', 'next-devel', 'branched', 'rawhide', 'bodhi-updates', 'developer'],
+                    // source of truth for arches; ideally this would come from aggregating builds.json
+                    archList: ['x86_64', 'aarch64'],
                     // currently selected stream
                     stream: 'testing-devel',
+                    // currently selected architecture
+                    arch: 'x86_64',
                     // if current stream is "developer", currently entered developer
                     developer: "",
                     // current url to builds/ dir for stream
                     buildsUrl: "",
                     // list of {id, arches, meta, commitmeta} build objects
-                    // XXX: in the future these would be e.g.
-                    // meta[arch] and commitmeta[arch]
                     builds: [],
                     // list of unshown {id, arches, meta, commitmeta} build objects
                     unshown_builds: [],
@@ -415,14 +448,27 @@
                 },
                 created: function() {
                     let searchParams = new URLSearchParams(window.location.search);
+                    let updateHistory = false;
                     if (searchParams.has('stream')) {
                         const queryStream = searchParams.get('stream');
                         if (this.streamList.includes(queryStream)) {
                             this.stream = queryStream;
                         } else {
                             searchParams.set('stream', this.stream);
-                            history.replaceState(null, null, `${window.location.origin + window.location.pathname}?${searchParams.toString()}`);
+                            updateHistory = true;
                         }
+                    }
+                    if (searchParams.has('arch')) {
+                        const queryArch = searchParams.get('arch');
+                        if (this.archList.includes(queryArch)) {
+                            this.arch = queryArch;
+                        } else {
+                            searchParams.set('arch', this.arch);
+                            updateHistory = true;
+                        }
+                    }
+                    if (updateHistory) {
+                        history.replaceState(null, null, `${window.location.origin + window.location.pathname}?${searchParams.toString()}`);
                     }
 
                     this.refreshBuilds();
@@ -431,11 +477,15 @@
                     stream() {
                         this.updateURL();
                         this.refreshBuilds();
+                    },
+                    arch() {
+                        this.updateURL();
+                        this.refreshArch();
                     }
                 },
                 methods: {
                     updateURL: function() {
-                        history.replaceState(null, null, `${window.location.origin + window.location.pathname}?stream=${this.stream}`);
+                        history.replaceState(null, null, `${window.location.origin + window.location.pathname}?stream=${this.stream}&arch=${this.arch}`);
                     },
                     refreshBuilds: function() {
                         this.loading = true
@@ -450,11 +500,16 @@
                             builds.forEach((build, idx) => {
                                 if (idx < initialBuildsShown) {
                                     this.builds.push(build);
-                                    fetchBuild(this.buildsUrl, build);
+                                    fetchBuild(this.buildsUrl, build, this.arch);
                                 } else {
                                     this.unshown_builds.push(build);
                                 }
                             })
+                        });
+                    },
+                    refreshArch: function() {
+                        this.builds.forEach((build, idx) => {
+                            fetchBuild(this.buildsUrl, build, this.arch);
                         });
                     },
                     loadMoreBuilds: function(n) {
@@ -463,7 +518,7 @@
                         unshown_builds.forEach((build, idx) => {
                             if (n < 0 || idx < n) {
                                 this.builds.push(build);
-                                fetchBuild(this.buildsUrl, build);
+                                fetchBuild(this.buildsUrl, build, this.arch);
                             } else {
                                 this.unshown_builds.push(build);
                             }
@@ -471,18 +526,18 @@
                     },
                     getImageUrl: function(build, type) {
                         var path = build.meta['images'][type]['path'];
-                        var url = getArtifactUrl(this.buildsUrl, build, path);
+                        var url = getArtifactUrl(this.buildsUrl, build, this.arch, path);
                         return `<a href="${url}">${path}</a> ` +
                             `(<a title="Copy image link to clipboard" class="js"
                                  onclick="copyToClipboard('${url}')">copy link</a>)`;
                     },
                     getObjectUrl: function(build, path) {
-                        return getArtifactUrl(this.buildsUrl, build, path);
+                        return getArtifactUrl(this.buildsUrl, build, this.arch, path);
                     },
                     getOSTreeUrl: function(build) {
                         if ('ostree' in build.meta['images']) {
                             var path = build.meta['images']['ostree']['path'];
-                            return getArtifactUrl(this.buildsUrl, build, path);
+                            return getArtifactUrl(this.buildsUrl, build, this.arch, path);
                         }
                         return this.getObjectUrl(build, "ostree-commit.tar")
                     },


### PR DESCRIPTION
We're now producing aarch64 images. Add a selector for this in the
browser so it's accessible. We always initially load just the x86_64
metadata, and only fetch the metadata for other arches when requested.