### PR TITLE
Add containerd to important packages

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -335,7 +335,7 @@
 
             // pkgdiff enum to str
             const diffType = ["added", "removed", "upgraded", "downgraded"];
-            const importantPkgs = ["kernel", "systemd", "rpm-ostree", "ignition", "podman", "moby-engine"];
+            const importantPkgs = ["kernel", "systemd", "rpm-ostree", "ignition", "podman", "moby-engine", "containerd"];
 
             // RpmOstreeAdvisorySeverity enum to str
             const advisorySeverityType = ["none", "low", "moderate", "important", "critical"];


### PR DESCRIPTION
containerd is the default runtime for k8s (which probably is a big usage of fcos)