### PR TITLE
Add the KubeVirt ociarchive artifact to the browser

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -175,6 +175,9 @@
                                                     <li v-if="'initramfs' in build.meta.images">
                                                         Installer Initramfs: <span v-html="getImageUrl(build, 'initramfs')"></span>
                                                     </li>
+                                                    <li v-if="'kubevirt' in build.meta.images">
+                                                        KubeVirt: <span v-html="getImageUrl(build, 'kubevirt')"></span>
+                                                    </li>
                                                     <li v-if="'live-iso' in build.meta.images">
                                                         Live ISO: <span v-html="getImageUrl(build, 'live-iso')"></span>
                                                     </li>


### PR DESCRIPTION
Add the ociarchive from the metadata which looks somewhat like this:

```
    "images": {
        "ostree": {
            "path": "fedora-coreos-35.20220412.dev.0-ostree.x86_64.ociarchive",
            "sha256": "fa58a55fec683dcbf7f8c57bf06dd183258ed1e450e0c8fd978fe039bb6c0b80",
            "size": 1487249920,
            "skip-compression": true
        },
        "qemu": {
            "path": "fedora-coreos-35.20220412.dev.0-qemu.x86_64.qcow2",
            "sha256": "a554c002682b7671683fbbbb66b511abe83ca37fdd4c32414c210d4dfd1af33a",
            "size": 1619263488
        },
        "kubevirt": {
            "path": "fedora-coreos-35.20220412.dev.0-kubevirt.x86_64.ociarchive",
            "sha256": "44b634f448f67c27c749767e7c0b501cca0272993441e051890194cda2b006a2",
            "size": 854137344
        }
    },
```

and add it to the browser.

xref https://github.com/coreos/fedora-coreos-tracker/issues/1126