### PR TITLE
Add line break after container images

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -51,11 +51,11 @@
                                                 </ul>
                                             </div>
                                             <div v-if="'base-oscontainer' in build.meta" class="content">
-                                                Base Container Image:
+                                                Base Container Image:<br>
                                                 <span v-html="getClickableContainerImage(build.meta['base-oscontainer'])"></span>
                                             </div>
                                             <div v-if="'extensions-container' in build.meta" class="content">
-                                                Extensions Container Image:
+                                                Extensions Container Image:<br>
                                                 <span v-html="getClickableContainerImage(build.meta['extensions-container'])"></span>
                                             </div>
                                             <div class="content">


### PR DESCRIPTION
This avoids line breaking the image reference on narrower screens at least.