### PR TITLE
browser: fix release load failure if `base-oscontainer.digest` missing

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -579,8 +579,17 @@
                         })
                     },
                     getClickableContainerImage: function(img, tag) {
-                        var pullspec = img.image + '@' + img.digest;
-                        var pullspec_disp = img.image + '@' + img.digest.slice(0, "sha256:".length + 12) + '...';
+                        var pullspec = img.image;
+                        var pullspec_disp = img.image;
+                        if (img.digest !== undefined) {
+                            pullspec += '@' + img.digest;
+                            pullspec_disp += '@' + img.digest.slice(0, "sha256:".length + 12) + '...';
+                        } else {
+                            var index = pullspec.indexOf('@sha256:');
+                            if (index != -1) {
+                                pullspec_disp = pullspec.slice(0, index + 20) + '...';
+                            }
+                        }
                         if (tag !== undefined) {
                             pullspec = img.image + ':' + tag;
                             pullspec_disp = pullspec

--- a/browser/index.html
+++ b/browser/index.html
@@ -581,7 +581,7 @@
                     getClickableContainerImage: function(img, tag) {
                         var pullspec = img.image + '@' + img.digest;
                         var pullspec_disp = img.image + '@' + img.digest.slice(0, "sha256:".length + 12) + '...';
-                        if (tag != undefined) {
+                        if (tag !== undefined) {
                             pullspec = img.image + ':' + tag;
                             pullspec_disp = pullspec
                         }


### PR DESCRIPTION
Release details were getting stuck at "Loading..." for releases whose `meta.json` doesn't have the `base-oscontainer.digest` field.

Fixes error:

    vue@2:11 TypeError: Cannot read properties of undefined (reading 'slice')
        at Cr.getClickableContainerImage (browser:583:74)

Fixes #41.

cc @cgwalters 