### PR TITLE
browser: tolerate missing coreos-assembler metadata

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -45,8 +45,12 @@
                                             <div class="content">
                                                 Metadata:
                                                 <ul>
-                                                    <li> FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.config-gitrev']">{{ build.meta['coreos-assembler.config-gitrev'] }}</a></li>
-                                                    <li> COSA Commit: <a v-bind:href="'https://github.com/coreos/coreos-assembler/commit/' + build.meta['coreos-assembler.container-image-git']['commit']">{{ build.meta['coreos-assembler.container-image-git']['commit'] }}</a></li>
+                                                    <li v-if="build.meta['coreos-assembler.config-gitrev']">
+                                                        FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.config-gitrev']">{{ build.meta['coreos-assembler.config-gitrev'] }}</a>
+                                                    </li>
+                                                    <li v-if="build.meta['coreos-assembler.container-image-git']">
+                                                        COSA Commit: <a v-bind:href="'https://github.com/coreos/coreos-assembler/commit/' + build.meta['coreos-assembler.container-image-git']['commit']">{{ build.meta['coreos-assembler.container-image-git']['commit'] }}</a>
+                                                    </li>
                                                     <li> Raw: <a v-bind:href="getObjectUrl(build, 'meta.json')">meta.json</a> <a v-bind:href="getObjectUrl(build, 'commitmeta.json')">commitmeta.json</a></li>
                                                 </ul>
                                             </div>


### PR DESCRIPTION
The current builds done with the buildah path are missing some of the usual git metadata for the source repo and cosa repo.

We do want that information in there (though for the source config repo, using the standard OCI org.opencontainers labels, which will end up in `meta.json` already since we now capture all labels there), but for now at least let's tolerate that information missing so builds show up.