### PR TITLE
use newer API for coreos config git rev

### DIFF
--- a/browser/index.html
+++ b/browser/index.html
@@ -45,8 +45,8 @@
                                             <div class="content">
                                                 Metadata:
                                                 <ul>
-                                                    <li v-if="build.meta['coreos-assembler.config-gitrev']">
-                                                        FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.config-gitrev']">{{ build.meta['coreos-assembler.config-gitrev'] }}</a>
+                                                    <li v-if="build.meta['coreos-assembler.container-config-git']">
+                                                        FCOS Commit: <a v-bind:href="'https://github.com/coreos/fedora-coreos-config/commit/' + build.meta['coreos-assembler.container-config-git']['commit']">{{ build.meta['coreos-assembler.container-config-git']['commit'] }}</a>
                                                     </li>
                                                     <li v-if="build.meta['coreos-assembler.container-image-git']">
                                                         COSA Commit: <a v-bind:href="'https://github.com/coreos/coreos-assembler/commit/' + build.meta['coreos-assembler.container-image-git']['commit']">{{ build.meta['coreos-assembler.container-image-git']['commit'] }}</a>


### PR DESCRIPTION
The .config-gitrev is legacy. Let's update to use the newer API.

xref: https://github.com/coreos/coreos-assembler/pull/4282