### PR TITLE
graph: always query the OCI graph

### DIFF
--- a/graph/index.html
+++ b/graph/index.html
@@ -173,7 +173,7 @@ function templateUrl() {
 
   var oci = urlParams.get('oci');
   if (oci === null) {
-    oci = false;
+    oci = true;
   }
 
   const updatesUrl = `https://raw-updates.coreos.${infraPrefix}fedoraproject.org/v1/graph?basearch=${basearch}&stream=${stream}&oci=${oci}`;


### PR DESCRIPTION
Now that we are defaulted to OCI updates and are no longer shipping OSTree commits to the repo, let's show the OCI graph by default.

Prompted by https://github.com/coreos/fedora-coreos-streams/pull/1137